### PR TITLE
fix: pin pandoc dockerfile base to 3.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/latex
+FROM pandoc/latex:3.1.1
  
 ARG ENVIRONMENT=production
 


### PR DESCRIPTION
Changes to pandoc version will likely require the reference documents used in tests to be updated